### PR TITLE
fix: prevent scenes/prefabs from becoming dirty

### DIFF
--- a/Packages/com.gametoolkit.localization/Runtime/LocalizedGenericAssetBehaviourBase.cs
+++ b/Packages/com.gametoolkit.localization/Runtime/LocalizedGenericAssetBehaviourBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) H. Ibrahim Penekli. All rights reserved.
+﻿// Copyright (c) H. Ibrahim Penekli. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
@@ -36,19 +36,29 @@ namespace GameToolkit.Localization
             }
 #endif
 
-            if (HasLocalizedValue() && m_PropertyInfo != null)
+            if (!HasLocalizedValue() || m_PropertyInfo == null)
             {
-#if UNITY_EDITOR
-                if (!Application.isPlaying)
-                {
-                    UnityEditor.Undo.RecordObject(m_Component, "Locale value change");
-                }
-#endif
-                m_PropertyInfo.SetValue(m_Component, GetLocalizedValue(), null);
-                return true;
+                return false;
             }
 
-            return false;
+            var newValue = GetLocalizedValue();
+            var canRead = m_PropertyInfo.CanRead;
+            if (canRead)
+            {
+                var currentValue = m_PropertyInfo.GetValue(m_Component, null);
+                if (AreValuesEqual(currentValue, newValue))
+                {
+                    return false;
+                }
+            }
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                UnityEditor.Undo.RecordObject(m_Component, "Locale value change");
+            }
+#endif
+            m_PropertyInfo.SetValue(m_Component, newValue, null);
+            return true;
         }
 
         private void InitializePropertyIfNeeded()
@@ -69,7 +79,7 @@ namespace GameToolkit.Localization
 
             return false;
         }
-        
+
         public bool TrySetComponentAndProperty<TComponent>(string propertyName)
             where TComponent : Component
         {
@@ -77,7 +87,7 @@ namespace GameToolkit.Localization
             if (m_Component != null)
             {
                 m_Property = propertyName;
-                
+
                 if (!TryInitializeProperty())
                 {
                     m_Property = "";
@@ -100,7 +110,7 @@ namespace GameToolkit.Localization
 
             return false;
         }
-        
+
         private PropertyInfo FindProperty(Component component, string propertyName)
         {
             return component.GetType().GetProperty(propertyName, GetValueType());
@@ -123,6 +133,21 @@ namespace GameToolkit.Localization
             }
 
             return properties;
+        }
+
+        private static bool AreValuesEqual(object currentValue, object newValue)
+        {
+            if (ReferenceEquals(currentValue, newValue))
+            {
+                return true;
+            }
+
+            if (currentValue is UnityEngine.Object currentObject && newValue is UnityEngine.Object newObject)
+            {
+                return currentObject == newObject;
+            }
+
+            return Equals(currentValue, newValue);
         }
     }
 }


### PR DESCRIPTION
fix: prevent scenes/prefabs from becoming dirty when localized values are unchanged

- Add value comparison in TryUpdateComponentLocalization before applying changes
- Only record undo and set property values when localized content actually differs
- Handle UnityEngine.Object equality properly using Unity's == operator
- Resolves issue where saving C# files or opening prefabs with localization components would unnecessarily mark scenes/prefabs as dirty

Check the issue here https://github.com/ibrahimpenekli/GameToolkit-Localization/issues/26